### PR TITLE
Enable flow for project

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,15 @@
+[ignore]
+<PROJECT_ROOT>/node_modules/.*
+
+[include]
+
+[libs]
+
+[lints]
+
+[options]
+
+[strict]
+
+[version]
+0.167.1

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/Khan/kmath",
   "devDependencies": {
+    "flow-bin": "0.167.1",
     "mocha": "^1.21.5",
     "webpack": "^3.8.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -839,6 +839,11 @@ find-up@^2.0.0:
   dependencies:
     locate-path "^2.0.0"
 
+flow-bin@0.167.1:
+  version "0.167.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.167.1.tgz#c2cfc2ca326ca16fbf9bf6ab273bb865b26b528b"
+  integrity sha512-YL3sy3YEa5do5O/dBmUFHqzsWGIj2Yhx3+FzNTQsmfimX5DTlUj9uC0LFmuG+c5pDtVo/d/1e38Vgd1o0fgh9g==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"


### PR DESCRIPTION
## Summary:

Khan Academy uses Flow to type-check Javascript. This PR adds Flow tooling
support (but does not add Flow typing yet).

Issue: "none"

## Test plan:

`yarn`
`yarn flow`